### PR TITLE
autodetect media information using python-magic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Please note: For BCAT protocol, it is very important to have an adequate number 
 
 3. Basic Utilities
 
-Some basic utilities are included for working with utxo splitting and manually extracting the media type / handling of the file based on the file path (with extension) - to cover some potentially more advanced useage patterns of the B and BCAT protocols.
+Some basic utilities are included for working with utxo splitting and extracting the media type / handling of the file based on the file path (with extension and content) - to cover some potentially more advanced useage patterns of the B and BCAT protocols.
 
 .. code-block:: python
 

--- a/polyglot/__init__.py
+++ b/polyglot/__init__.py
@@ -1,5 +1,5 @@
 import bitsv
 
-from polyglot.upload import Upload, MEDIA_TYPE, ENCODINGS, B, C, BCAT, BCATPART, D, AIP, MAP
+from polyglot.upload import Upload, B, C, BCAT, BCATPART, D, AIP, MAP
 
 __version__ = '0.0.3'

--- a/polyglot/upload.py
+++ b/polyglot/upload.py
@@ -18,39 +18,6 @@ MAP = '1PuQa7K62MiKCtssSLKy1kh56WWU7MtUR5'  # MAP protocol.
 SPACE_AVAILABLE_PER_TX_BCAT_PART = 100000 - len(BCATPART.encode('utf-8')) - 10000  # temporary hack (-) 10,000 bytes
 
 
-MEDIA_TYPE = {
-    # Images
-    'png': 'image/png',
-    'jpg': 'image/jpeg',
-
-    # Documents
-    'txt': 'text/plain',
-    'html': 'text/html',
-    'css': 'text/css',
-    'js': 'text/javascript',
-    'pdf': 'application/pdf',
-
-    # Audio
-    'mp3': 'audio/mp3',
-}
-
-ENCODINGS = {
-    # Images
-    'png': 'binary',
-    'jpg': 'binary',
-
-    # Documents
-    'txt': 'utf-8',
-    'html': 'utf-8',
-    'css': 'utf-8',
-    'js': 'utf-8',
-    'pdf': 'binary',
-
-    # Audio
-    'mp3': 'binary',
-}
-
-
 class Upload(bitsv.PrivateKey):
     """
     A simple interface to a multitude of bitcoin protocols
@@ -89,19 +56,13 @@ class Upload(bitsv.PrivateKey):
         ext = file.split(r".")[1].strip(r"'")
         return ext
 
-    @staticmethod
-    def get_media_type_for_extension(ext):
-        return MEDIA_TYPE[str(ext)]
-
-    @staticmethod
-    def get_encoding_type_for_extension(ext):
-        return ENCODINGS[str(ext)]
-
     def get_media_type_for_file_name(self, file):
-        return self.get_media_type_for_extension(self.get_file_ext(file))
+        import magic
+        return magic.from_file(file, mime=True)
 
     def get_encoding_for_file_name(self, file):
-        return self.get_encoding_type_for_extension(self.get_file_ext(file))
+        import magic
+        return magic.Magic(mime_encoding=True).from_file(file)
 
     def send_rawtx(self, rawtx):
         return self.woc.send_transaction(rawtx)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 
-    install_requires=['bitsv', 'requests'],
+    install_requires=['bitsv', 'requests', 'python-magic'],
     extras_require={
         'cli': ('appdirs', 'click', 'privy', 'tinydb'),
         'cache': ('lmdb', ),


### PR DESCRIPTION
The first issue I run into when using this library is that most files throw exceptions unless media information is manually provided.

This PR changes the default handling so that all files are accepted and given detected values.