### PR TITLE
Add informative data on fresh utxos

### DIFF
--- a/polyglot/upload.py
+++ b/polyglot/upload.py
@@ -223,7 +223,8 @@ class Upload(bitsv.PrivateKey):
             pass
         else:
             raise ValueError("insufficient 'Fresh' unspent transaction outputs (utxos) to complete the "
-                             "BCAT upload. Please generate more 'Fresh' utxos and try again")
+                             "BCAT upload (" + str(len(utxos)) + " < " + str(number_bcat_parts) + "). "
+                             "Please generate more 'Fresh' utxos and try again")
 
         for i in range(number_bcat_parts):
             data = stream.read(SPACE_AVAILABLE_PER_TX_BCAT_PART)


### PR DESCRIPTION
This adds the count of utxo to the error thrown when there are not enough.